### PR TITLE
Add haptic feedback to puzzle attempts and update related tests

### DIFF
--- a/convex/notifications/queries.ts
+++ b/convex/notifications/queries.ts
@@ -18,7 +18,7 @@ export const registerUserForNotifications = mutation({
   handler: async (ctx, { userId, pushToken }) => {
     await pushNotifications.recordToken(ctx, { userId, pushToken });
     // TODO: Add this back once fixed
-    await pushNotifications.unpauseNotificationsForUser(ctx, { userId });
+    // await pushNotifications.unpauseNotificationsForUser(ctx, { userId });
   },
 });
 

--- a/src/hooks/useDailyPuzzle/useDailyPuzzle.ts
+++ b/src/hooks/useDailyPuzzle/useDailyPuzzle.ts
@@ -1,3 +1,4 @@
+import * as Haptics from 'expo-haptics';
 import { usePostHog } from 'posthog-react-native';
 
 import { isAttemptCorrect } from '@/convex/puzzleGuessAttempts/helpers';
@@ -24,16 +25,15 @@ export function useDailyPuzzle() {
   const handleCreatePuzzleGuessAttempt = async (attempt: string) => {
     try {
       const { isCorrect } = await createPuzzleGuessAttempt({
-        data: {
-          userId: user?._id!,
-          puzzleId: puzzle?._id!,
-          attempt,
-        },
+        data: { userId: user?._id!, puzzleId: puzzle?._id!, attempt },
       });
 
       if (isCorrect) {
+        await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
         markPuzzleAsSolved({ puzzleId: puzzle?._id!, userId: user?._id! });
         posthog.capture('puzzle:solved', { puzzleId: puzzle?._id!, userId: user?._id!, type: puzzleType.Enum.daily });
+      } else {
+        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
       }
     } catch {
       toaster.toast('Nekaj je šlo narobe.', { intent: 'error' });

--- a/src/hooks/useTrainingPuzzle/useTrainingPuzzle.ts
+++ b/src/hooks/useTrainingPuzzle/useTrainingPuzzle.ts
@@ -1,3 +1,4 @@
+import * as Haptics from 'expo-haptics';
 import { usePostHog } from 'posthog-react-native';
 import { useCallback, useEffect } from 'react';
 
@@ -30,7 +31,15 @@ export function useTrainingPuzzle() {
 
   const handleCreatePuzzleGuessAttempt = async (attempt: string) => {
     try {
-      await createPuzzleGuessAttempt({ data: { userId: user?._id!, puzzleId: puzzle?._id!, attempt } });
+      const { isCorrect } = await createPuzzleGuessAttempt({
+        data: { userId: user?._id!, puzzleId: puzzle?._id!, attempt },
+      });
+
+      if (isCorrect) {
+        await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+      } else {
+        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      }
     } catch {
       toaster.toast('Nekaj je šlo narobe.', { intent: 'error' });
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added haptic feedback when submitting puzzle attempts. Success triggers a success notification vibration, while incorrect attempts trigger a medium impact vibration for both daily and training puzzles.

* **Tests**
  * Enhanced test coverage to verify correct haptic feedback is triggered for both correct and incorrect puzzle attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->