### PR TITLE
[PET-20] Add query index to read puzzle query (Optimize dictionary entry query to use specific database index)

### DIFF
--- a/convex/dictionary/queries.ts
+++ b/convex/dictionary/queries.ts
@@ -9,7 +9,7 @@ export const read = query({
   async handler(ctx, args) {
     const term = await ctx.db
       .query('dictionaryEntries')
-      .filter((q) => q.eq(q.field('word'), args.term))
+      .withIndex('dictionary_word', (q) => q.eq('word', args.term))
       .first();
 
     return term;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the performance of dictionary entry lookups, resulting in potentially faster search results for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->