### PR TITLE
[PET-21] Adjust weights when picking random daily word (Add tests for pickRandomWord and update default decayFactor to 2.5)

### DIFF
--- a/src/utils/words.test.ts
+++ b/src/utils/words.test.ts
@@ -1,0 +1,41 @@
+import { pickRandomWord } from './words';
+
+describe('pickRandomWord', () => {
+  const words = [
+    { word: 'apple', frequency: 10, numOfTimesUsed: 0 },
+    { word: 'banana', frequency: 5, numOfTimesUsed: 2 },
+    { word: 'cherry', frequency: 2, numOfTimesUsed: 5 },
+  ];
+
+  beforeEach(() => {
+    jest.spyOn(global.Math, 'random');
+  });
+
+  afterEach(() => {
+    (Math.random as jest.Mock).mockRestore();
+  });
+
+  it('should throw an error when given an empty array', () => {
+    expect(() => pickRandomWord([])).toThrow('No words to choose from');
+  });
+
+  it('should return the expected word based on controlled random number (first item)', () => {
+    (Math.random as jest.Mock).mockReturnValue(0.00001);
+    const result = pickRandomWord(words);
+    expect(result).toBe('apple');
+  });
+
+  it('should return the expected word based on controlled random number (last item)', () => {
+    (Math.random as jest.Mock).mockReturnValue(0.999);
+    const result = pickRandomWord(words);
+    expect(result).toBe('cherry');
+  });
+
+  it('should respect decayFactor (higher decay penalizes used words more)', () => {
+    const lowDecayResult = pickRandomWord(words, 0.5);
+    const highDecayResult = pickRandomWord(words, 5);
+
+    expect(['apple', 'banana', 'cherry']).toContain(lowDecayResult);
+    expect(['apple', 'banana', 'cherry']).toContain(highDecayResult);
+  });
+});

--- a/src/utils/words.ts
+++ b/src/utils/words.ts
@@ -6,7 +6,7 @@ type WordEntry = {
   numOfTimesUsed: number;
 };
 
-export function pickRandomWord(words: WordEntry[], decayFactor = 1.75) {
+export function pickRandomWord(words: WordEntry[], decayFactor = 2.5) {
   if (words.length === 0) throw new Error('No words to choose from');
 
   const weights = words.map((w) => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the word selection process by adjusting the weighting calculation for picking random words.

* **Tests**
  * Added comprehensive tests to ensure correct behavior of the word selection logic, including edge cases and parameter variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->