### PR TITLE
[PET-26] The 6th attempts can't be submitted when auto-verify option is off (GuessGrid helpers return 6 when full; autosubmit only when enabled)

### DIFF
--- a/src/components/elements/GuessGrid/GuessGrid.helpers.ts
+++ b/src/components/elements/GuessGrid/GuessGrid.helpers.ts
@@ -3,7 +3,8 @@ import { deepClone } from '@/utils/clone';
 import { type KeyboardKey } from '../Keyboard';
 
 export const findCurrentGridRowIdx = (grid: (string | null)[][]) => {
-  return grid.findIndex((row) => !row.every(Boolean));
+  const rowIdx = grid.findIndex((row) => !row.every(Boolean));
+  return rowIdx >= 0 ? rowIdx : 6;
 };
 
 export const findCellIndexToInsert = (grid: (string | null)[][], rowIdx: number) => {

--- a/src/components/elements/GuessGrid/GuessGrid.helpers.ts
+++ b/src/components/elements/GuessGrid/GuessGrid.helpers.ts
@@ -4,7 +4,7 @@ import { type KeyboardKey } from '../Keyboard';
 
 export const findCurrentGridRowIdx = (grid: (string | null)[][]) => {
   const rowIdx = grid.findIndex((row) => !row.every(Boolean));
-  return rowIdx >= 0 ? rowIdx : 6;
+  return rowIdx >= 0 ? rowIdx : grid.length;
 };
 
 export const findCellIndexToInsert = (grid: (string | null)[][], rowIdx: number) => {

--- a/src/components/elements/GuessGrid/GuessGrid.hook.ts
+++ b/src/components/elements/GuessGrid/GuessGrid.hook.ts
@@ -126,10 +126,10 @@ export function useGuessGrid({ attempts, onSubmitAttempt }: Options) {
 
       setGuesses(updatedGuesses);
 
-      const currentGuess = updatedGuesses[rowIdx].filter(Boolean);
+      if (autosubmitPuzzleAttempt) {
+        const currentGuess = updatedGuesses[rowIdx].filter(Boolean);
 
-      if (currentGuess.length === 5) {
-        if (autosubmitPuzzleAttempt) {
+        if (currentGuess.length === 5) {
           await handleSubmitPuzzleAttempt(currentGuess.join(''), updatedGuesses, rowIdx);
         }
       }


### PR DESCRIPTION
Fixes #24 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Autosubmit now only triggers when enabled, preventing unintended submissions or processing.
  - Fixed edge-case when the guess grid is full to avoid errors and ensure correct end-of-guess behavior.
  - Smoother handling after all rows are completed to reduce unexpected app behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->