### PR TITLE
[PET-29] Remove global leaderboard (Deprecate readGlobalLeaderboard; remove hooks; debug-off Sentry)

### DIFF
--- a/convex/leaderboards/queries.ts
+++ b/convex/leaderboards/queries.ts
@@ -89,6 +89,9 @@ export const list = query({
   },
 });
 
+/**
+ * @deprecated Removed with version 1.1.40
+ */
 export const readGlobalLeaderboard = query({
   args: { range: leaderboardRange, userId: z.string(), timestamp: z.number() },
   async handler(ctx, { range, userId, timestamp }) {

--- a/src/__tests__/leaderboards/all-time-leaderboard.test.tsx
+++ b/src/__tests__/leaderboards/all-time-leaderboard.test.tsx
@@ -3,19 +3,13 @@ import { useNavigation } from 'expo-router';
 
 import AllTimeLeaderboardScreen from '@/app/(authenticated)/leaderboards/all-time-leaderboard';
 import { leaderboardRange, leaderboardType } from '@/convex/leaderboards/models';
-import { useGlobalLeaderboard } from '@/hooks/useGlobalLeaderboard';
 import { useLeaderboards } from '@/hooks/useLeaderboards';
-import { testGlobalLeaderboard1, testPrivateLeaderboard1 } from '@/tests/fixtures/leaderboards';
+import { testPrivateLeaderboard1 } from '@/tests/fixtures/leaderboards';
 
 jest.mock('expo-router', () => ({
   ...jest.requireActual('expo-router'),
   useFocusEffect: jest.fn().mockImplementation((cb) => cb()),
   useNavigation: jest.fn().mockReturnValue({}),
-}));
-
-jest.mock('@/hooks/useGlobalLeaderboard', () => ({
-  ...jest.requireActual('@/hooks/useGlobalLeaderboard'),
-  useGlobalLeaderboard: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock('@/hooks/useLeaderboards', () => ({
@@ -30,12 +24,10 @@ describe('<AllTimeLeaderboardScreen />', () => {
   const mockSetOptions = jest.fn();
 
   const useNavigationSpy = useNavigation as jest.Mock;
-  const useGlobalLeaderboardSpy = useGlobalLeaderboard as jest.Mock;
   const useLeaderboardsSpy = useLeaderboards as jest.Mock;
 
   beforeEach(() => {
     useNavigationSpy.mockReturnValue({ getParent: jest.fn().mockReturnValue({ setOptions: mockSetOptions }) });
-    useGlobalLeaderboardSpy.mockReturnValue({ data: testGlobalLeaderboard1 });
     useLeaderboardsSpy.mockReturnValue({
       leaderboards: [testPrivateLeaderboard1],
       isCreating: false,
@@ -52,8 +44,6 @@ describe('<AllTimeLeaderboardScreen />', () => {
 
   it('should trigger global leaderboard and private leaderboards queries with "alltime" param', () => {
     render(<AllTimeLeaderboardScreen />);
-
-    expect(useGlobalLeaderboardSpy).toHaveBeenCalledWith(leaderboardRange.Enum.alltime);
     expect(useLeaderboardsSpy).toHaveBeenCalledWith(leaderboardType.Enum.private, leaderboardRange.Enum.alltime);
   });
 
@@ -63,11 +53,9 @@ describe('<AllTimeLeaderboardScreen />', () => {
     expect(mockSetOptions).toHaveBeenCalledWith({ title: 'Lestvica vseh časov' });
   });
 
-  it('should render global and private leaderboards', () => {
+  it('should render private leaderboards', () => {
     render(<AllTimeLeaderboardScreen />);
 
-    expect(screen.queryByText('Globalna lestvica')).toBeOnTheScreen();
-    expect(screen.queryByText('Tvoje lestvice')).toBeOnTheScreen();
     expect(screen.queryByText(testPrivateLeaderboard1.name!)).toBeOnTheScreen();
   });
 
@@ -98,7 +86,7 @@ describe('<AllTimeLeaderboardScreen />', () => {
       useLeaderboardsSpy.mockReturnValue({ leaderboards });
       render(<AllTimeLeaderboardScreen />);
 
-      expect(screen.queryByText('Pridružen/a nisi še nobeni zasebni lestvici...')).toBeOnTheScreen();
+      expect(screen.queryByText('Pridružen/a nisi še nobeni lestvici...')).toBeOnTheScreen();
     }
   );
 });

--- a/src/__tests__/leaderboards/weekly-leaderboard.test.tsx
+++ b/src/__tests__/leaderboards/weekly-leaderboard.test.tsx
@@ -3,19 +3,13 @@ import { useNavigation } from 'expo-router';
 
 import WeeklyLeaderboardScreen from '@/app/(authenticated)/leaderboards/weekly-leaderboard';
 import { leaderboardRange, leaderboardType } from '@/convex/leaderboards/models';
-import { useGlobalLeaderboard } from '@/hooks/useGlobalLeaderboard';
 import { useLeaderboards } from '@/hooks/useLeaderboards';
-import { testGlobalLeaderboard1, testPrivateLeaderboard1 } from '@/tests/fixtures/leaderboards';
+import { testPrivateLeaderboard1 } from '@/tests/fixtures/leaderboards';
 
 jest.mock('expo-router', () => ({
   ...jest.requireActual('expo-router'),
   useFocusEffect: jest.fn().mockImplementation((cb) => cb()),
   useNavigation: jest.fn().mockReturnValue({}),
-}));
-
-jest.mock('@/hooks/useGlobalLeaderboard', () => ({
-  ...jest.requireActual('@/hooks/useGlobalLeaderboard'),
-  useGlobalLeaderboard: jest.fn().mockReturnValue({}),
 }));
 
 jest.mock('@/hooks/useLeaderboards', () => ({
@@ -30,12 +24,10 @@ describe('<WeeklyLeaderboardScreen />', () => {
   const mockSetOptions = jest.fn();
 
   const useNavigationSpy = useNavigation as jest.Mock;
-  const useGlobalLeaderboardSpy = useGlobalLeaderboard as jest.Mock;
   const useLeaderboardsSpy = useLeaderboards as jest.Mock;
 
   beforeEach(() => {
     useNavigationSpy.mockReturnValue({ getParent: jest.fn().mockReturnValue({ setOptions: mockSetOptions }) });
-    useGlobalLeaderboardSpy.mockReturnValue({ data: testGlobalLeaderboard1 });
     useLeaderboardsSpy.mockReturnValue({
       leaderboards: [testPrivateLeaderboard1],
       isCreating: false,
@@ -53,7 +45,6 @@ describe('<WeeklyLeaderboardScreen />', () => {
   it('should trigger global leaderboard and private leaderboards queries with "weekly" param', () => {
     render(<WeeklyLeaderboardScreen />);
 
-    expect(useGlobalLeaderboardSpy).toHaveBeenCalledWith(leaderboardRange.Enum.weekly);
     expect(useLeaderboardsSpy).toHaveBeenCalledWith(leaderboardType.Enum.private, leaderboardRange.Enum.weekly);
   });
 
@@ -63,11 +54,9 @@ describe('<WeeklyLeaderboardScreen />', () => {
     expect(mockSetOptions).toHaveBeenCalledWith({ title: 'Tedenska lestvica' });
   });
 
-  it('should render global and private leaderboards', () => {
+  it('should render private leaderboards', () => {
     render(<WeeklyLeaderboardScreen />);
 
-    expect(screen.queryByText('Globalna lestvica')).toBeOnTheScreen();
-    expect(screen.queryByText('Tvoje lestvice')).toBeOnTheScreen();
     expect(screen.queryByText(testPrivateLeaderboard1.name!)).toBeOnTheScreen();
   });
 
@@ -98,7 +87,7 @@ describe('<WeeklyLeaderboardScreen />', () => {
       useLeaderboardsSpy.mockReturnValue({ leaderboards });
       render(<WeeklyLeaderboardScreen />);
 
-      expect(screen.queryByText('Pridružen/a nisi še nobeni zasebni lestvici...')).toBeOnTheScreen();
+      expect(screen.queryByText('Pridružen/a nisi še nobeni lestvici...')).toBeOnTheScreen();
     }
   );
 });

--- a/src/app/(authenticated)/leaderboards/all-time-leaderboard.tsx
+++ b/src/app/(authenticated)/leaderboards/all-time-leaderboard.tsx
@@ -6,12 +6,10 @@ import { StyleSheet } from 'react-native-unistyles';
 import { Leaderboard } from '@/components/elements';
 import { Button, Card, Text } from '@/components/ui';
 import { leaderboardRange, leaderboardType } from '@/convex/leaderboards/models';
-import { useGlobalLeaderboard } from '@/hooks/useGlobalLeaderboard';
 import { useLeaderboards } from '@/hooks/useLeaderboards';
 
 export default function AllTimeLeaderboardScreen() {
   const navigation = useNavigation();
-  const { data: globalLeaderboard } = useGlobalLeaderboard(leaderboardRange.Enum.alltime);
   const {
     leaderboards: privateLeaderboards,
     isCreating,
@@ -29,41 +27,33 @@ export default function AllTimeLeaderboardScreen() {
 
   return (
     <ScrollView contentContainerStyle={styles.container} contentInsetAdjustmentBehavior="automatic">
-      <Card title="Globalna lestvica">
-        <Leaderboard scores={globalLeaderboard?.scores} />
-      </Card>
-      <View style={styles.contentContainer}>
-        <Text size="lg" weight="medium">
-          Tvoje lestvice
-        </Text>
-        {privateLeaderboards?.length ? (
-          <View style={styles.privateLeaderboardsContainer}>
-            {privateLeaderboards.map((leaderboard) => (
-              <Card
-                key={leaderboard._id}
-                onShowActions={() => onPresentLeaderboardActions(leaderboard)}
-                title={leaderboard.name ?? leaderboard._id}
-              >
-                <Leaderboard scores={leaderboard.scores} />
-              </Card>
-            ))}
-          </View>
-        ) : (
-          <View style={styles.noLeaderboardsContainer}>
-            <Image source={require('@/assets/images/no-leaderboards.png')} style={styles.image} />
-            <Text align="center" color="grey70" size="sm">
-              Pridružen/a nisi še nobeni zasebni lestvici...
-            </Text>
-          </View>
-        )}
-        <View style={styles.actions}>
-          <Button intent="terciary" loading={isJoining} onPress={onJoinPrivateLeaderboard} variant="fill">
-            Pridruži se lestvici
-          </Button>
-          <Button intent="terciary" loading={isCreating} onPress={onCreatePrivateLeaderboard} variant="outline">
-            Ustvari lestvico
-          </Button>
+      {privateLeaderboards?.length ? (
+        <View style={styles.privateLeaderboardsContainer}>
+          {privateLeaderboards.map((leaderboard) => (
+            <Card
+              key={leaderboard._id}
+              onShowActions={() => onPresentLeaderboardActions(leaderboard)}
+              title={leaderboard.name ?? leaderboard._id}
+            >
+              <Leaderboard scores={leaderboard.scores} />
+            </Card>
+          ))}
         </View>
+      ) : (
+        <View style={styles.noLeaderboardsContainer}>
+          <Image source={require('@/assets/images/no-leaderboards.png')} style={styles.image} />
+          <Text align="center" color="grey70" size="sm">
+            Pridružen/a nisi še nobeni lestvici...
+          </Text>
+        </View>
+      )}
+      <View style={styles.actions}>
+        <Button intent="terciary" loading={isJoining} onPress={onJoinPrivateLeaderboard} variant="fill">
+          Pridruži se lestvici
+        </Button>
+        <Button intent="terciary" loading={isCreating} onPress={onCreatePrivateLeaderboard} variant="outline">
+          Ustvari lestvico
+        </Button>
       </View>
     </ScrollView>
   );
@@ -71,11 +61,8 @@ export default function AllTimeLeaderboardScreen() {
 
 const styles = StyleSheet.create((theme) => ({
   container: {
-    paddingTop: theme.spacing[8],
+    paddingTop: theme.spacing[6],
     paddingHorizontal: theme.spacing[6],
-  },
-  contentContainer: {
-    paddingVertical: theme.spacing[8],
   },
   noLeaderboardsContainer: {
     justifyContent: 'center',

--- a/src/app/(authenticated)/leaderboards/weekly-leaderboard.tsx
+++ b/src/app/(authenticated)/leaderboards/weekly-leaderboard.tsx
@@ -6,12 +6,10 @@ import { StyleSheet } from 'react-native-unistyles';
 import { Leaderboard } from '@/components/elements';
 import { Button, Card, Text } from '@/components/ui';
 import { leaderboardRange, leaderboardType } from '@/convex/leaderboards/models';
-import { useGlobalLeaderboard } from '@/hooks/useGlobalLeaderboard';
 import { useLeaderboards } from '@/hooks/useLeaderboards';
 
 export default function WeeklyLeaderboardScreen() {
   const navigation = useNavigation();
-  const { data: globalLeaderboard } = useGlobalLeaderboard(leaderboardRange.Enum.weekly);
   const {
     leaderboards: privateLeaderboards,
     isLoading,
@@ -30,45 +28,37 @@ export default function WeeklyLeaderboardScreen() {
 
   return (
     <ScrollView contentContainerStyle={styles.container} contentInsetAdjustmentBehavior="automatic">
-      <Card title="Globalna lestvica">
-        <Leaderboard scores={globalLeaderboard?.scores} />
-      </Card>
-      <View style={styles.contentContainer}>
-        <Text size="lg" weight="medium">
-          Tvoje lestvice
-        </Text>
-        {privateLeaderboards?.length ? (
-          <View style={styles.privateLeaderboardsContainer}>
-            {privateLeaderboards.map((leaderboard) => (
-              <Card
-                key={leaderboard._id}
-                onShowActions={() => onPresentLeaderboardActions(leaderboard)}
-                title={leaderboard.name ?? leaderboard._id}
-              >
-                <Leaderboard scores={leaderboard.scores} />
-              </Card>
-            ))}
-          </View>
-        ) : (
-          <>
-            {isLoading ? null : (
-              <View style={styles.noLeaderboardsContainer}>
-                <Image source={require('@/assets/images/no-leaderboards.png')} style={styles.image} />
-                <Text align="center" color="grey70" size="sm">
-                  Pridružen/a nisi še nobeni zasebni lestvici...
-                </Text>
-              </View>
-            )}
-          </>
-        )}
-        <View style={styles.actions}>
-          <Button intent="terciary" loading={isJoining} onPress={onJoinPrivateLeaderboard} variant="fill">
-            Pridruži se lestvici
-          </Button>
-          <Button intent="terciary" loading={isCreating} onPress={onCreatePrivateLeaderboard} variant="outline">
-            Ustvari lestvico
-          </Button>
+      {privateLeaderboards?.length ? (
+        <View style={styles.privateLeaderboardsContainer}>
+          {privateLeaderboards.map((leaderboard) => (
+            <Card
+              key={leaderboard._id}
+              onShowActions={() => onPresentLeaderboardActions(leaderboard)}
+              title={leaderboard.name ?? leaderboard._id}
+            >
+              <Leaderboard scores={leaderboard.scores} />
+            </Card>
+          ))}
         </View>
+      ) : (
+        <>
+          {isLoading ? null : (
+            <View style={styles.noLeaderboardsContainer}>
+              <Image source={require('@/assets/images/no-leaderboards.png')} style={styles.image} />
+              <Text align="center" color="grey70" size="sm">
+                Pridružen/a nisi še nobeni lestvici...
+              </Text>
+            </View>
+          )}
+        </>
+      )}
+      <View style={styles.actions}>
+        <Button intent="terciary" loading={isJoining} onPress={onJoinPrivateLeaderboard} variant="fill">
+          Pridruži se lestvici
+        </Button>
+        <Button intent="terciary" loading={isCreating} onPress={onCreatePrivateLeaderboard} variant="outline">
+          Ustvari lestvico
+        </Button>
       </View>
     </ScrollView>
   );
@@ -76,11 +66,8 @@ export default function WeeklyLeaderboardScreen() {
 
 const styles = StyleSheet.create((theme) => ({
   container: {
-    paddingTop: theme.spacing[8],
+    paddingTop: theme.spacing[6],
     paddingHorizontal: theme.spacing[6],
-  },
-  contentContainer: {
-    paddingVertical: theme.spacing[8],
   },
   noLeaderboardsContainer: {
     justifyContent: 'center',

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react-native';
 import { ConvexProvider, ConvexReactClient } from 'convex/react';
 import dayjs from 'dayjs';
 import { Asset } from 'expo-asset';
+import Constants from 'expo-constants';
 import { useFonts } from 'expo-font';
 import * as Notifications from 'expo-notifications';
 import { type Href, Stack, useGlobalSearchParams, usePathname, useRouter } from 'expo-router';
@@ -31,6 +32,7 @@ const convex = new ConvexReactClient(process.env.EXPO_PUBLIC_CONVEX_URL!, {
 });
 
 Sentry.init({
+  enabled: !Constants.debugMode,
   dsn: 'https://5239823974f8936789a62d8edb9beeb6@o4506279940587520.ingest.us.sentry.io/4509553115791360',
   sendDefaultPii: true,
   replaysSessionSampleRate: 0.1,

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -33,12 +33,15 @@ const convex = new ConvexReactClient(process.env.EXPO_PUBLIC_CONVEX_URL!, {
 
 Sentry.init({
   enabled: !Constants.debugMode,
-  dsn: 'https://5239823974f8936789a62d8edb9beeb6@o4506279940587520.ingest.us.sentry.io/4509553115791360',
+  dsn: Constants.debugMode
+    ? undefined
+    : 'https://5239823974f8936789a62d8edb9beeb6@o4506279940587520.ingest.us.sentry.io/4509553115791360',
   sendDefaultPii: true,
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1,
   tracesSampleRate: 1.0,
   profilesSampleRate: 1.0,
+  environment: process.env.APP_ENV,
   integrations: [
     Sentry.reactNavigationIntegration({ enableTimeToInitialDisplay: true }),
     Sentry.reactNativeTracingIntegration(),

--- a/src/hooks/queries/index.ts
+++ b/src/hooks/queries/index.ts
@@ -1,6 +1,5 @@
 export * from './useActiveDailyPuzzleQuery';
 export * from './useActiveTrainingPuzzleQuery';
-export * from './useGlobalLeaderboardQuery';
 export * from './useLeaderboardsQuery';
 export * from './usePuzzleAttemptsQuery';
 export * from './usePuzzleStatisticsQuery';

--- a/src/hooks/queries/useGlobalLeaderboardQuery.ts
+++ b/src/hooks/queries/useGlobalLeaderboardQuery.ts
@@ -1,7 +1,0 @@
-import { api } from '@/convex/_generated/api';
-
-import { generateUseQueryHookWithTimestampArg } from './generateUseQueryHook';
-
-export const useGlobalLeaderboardQuery = generateUseQueryHookWithTimestampArg(
-  api.leaderboards.queries.readGlobalLeaderboard
-);

--- a/src/hooks/useGlobalLeaderboard/index.ts
+++ b/src/hooks/useGlobalLeaderboard/index.ts
@@ -1,1 +1,0 @@
-export * from './useGlobalLeaderboard';

--- a/src/hooks/useGlobalLeaderboard/useGlobalLeaderboard.ts
+++ b/src/hooks/useGlobalLeaderboard/useGlobalLeaderboard.ts
@@ -1,9 +1,0 @@
-import { type LeaderboardRange } from '@/convex/leaderboards/models';
-
-import { useGlobalLeaderboardQuery } from '../queries';
-import { useUser } from '../useUser';
-
-export function useGlobalLeaderboard(range: LeaderboardRange) {
-  const { user } = useUser();
-  return useGlobalLeaderboardQuery(user?._id ? { range, userId: user._id } : 'skip');
-}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Leaderboard screens simplified to show only private leaderboards; global leaderboard section removed.
  - Join/Create actions relocated below the list or empty state for consistent access.
  - Layout spacing adjusted and empty-state message for private leaderboards updated.

- Chores
  - Error reporting disabled in debug builds and enabled in production for stability monitoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->