### PR TITLE
[PET-31] Guess grid text in dark mode should always be white (Derive GuessGrid cell text color via theme/checkedLetters function)

### DIFF
--- a/src/components/elements/GuessGrid/GuessGrid.tsx
+++ b/src/components/elements/GuessGrid/GuessGrid.tsx
@@ -16,13 +16,7 @@ function GuessGridCell({ testID, value, idx, checkedLetters = [], cellWidth }: R
 
   return (
     <View style={styles.cell({ isCorrect, isInvalid, isMisplaced, cellWidth })} testID={testID}>
-      <Text
-        allowFontScaling={false}
-        color={checkedLetters.length ? 'white' : 'black'}
-        size="xl"
-        style={styles.cellText}
-        weight="bold"
-      >
+      <Text allowFontScaling={false} size="xl" style={styles.cellText(!!checkedLetters.length)} weight="bold">
         {value}
       </Text>
     </View>
@@ -104,7 +98,12 @@ const styles = StyleSheet.create((theme, rt) => ({
       justifyContent: 'center',
     };
   },
-  cellText: {
-    textTransform: 'uppercase',
+  cellText(hasCheckedLetters: boolean) {
+    const inferredColor = hasCheckedLetters ? theme.colors.white : theme.colors.black;
+
+    return {
+      color: rt.themeName === 'dark' ? theme.colors.white : inferredColor,
+      textTransform: 'uppercase',
+    };
   },
 }));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Improved GuessGrid cell text readability with dynamic, theme-aware colors.
  - Ensures consistent white text in dark mode and appropriate contrast in light mode.
  - Maintains uppercase styling while adapting color based on whether letters have been checked.
  - Enhances visual consistency and clarity across game states without altering layout or interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->